### PR TITLE
fix: return 404 instead 500 for not found error

### DIFF
--- a/Chapter02/src/metadata/internal/handler/http/http.go
+++ b/Chapter02/src/metadata/internal/handler/http/http.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"movieexample.com/metadata/internal/controller/metadata"
-	"movieexample.com/metadata/internal/repository"
 )
 
 // Handler defines a movie metadata HTTP handler.
@@ -29,7 +28,7 @@ func (h *Handler) GetMetadata(w http.ResponseWriter, req *http.Request) {
 	}
 	ctx := req.Context()
 	m, err := h.ctrl.Get(ctx, id)
-	if err != nil && errors.Is(err, repository.ErrNotFound) {
+	if err != nil && errors.Is(err, metadata.ErrNotFound) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	} else if err != nil {


### PR DESCRIPTION
I found a subtle bug in chapter 2 source code.

The controller returns its own `ErrNotFound` instead of `ErrNotFound` found in `repository` package.
Since both regarded different error by go, the server always returns 500 Server Internal Error for 404 error.

When I executed the following command

```
$ curl -i 127.0.0.1:8081/metadata?id=1
```

Before fix
```
HTTP/1.1 500 Internal Server Error
Date: Thu, 22 Dec 2022 07:59:52 GMT
Content-Length: 0
```

After fix
```
HTTP/1.1 404 Not Found
Date: Thu, 22 Dec 2022 08:00:33 GMT
Content-Length: 0
```