### PR TITLE
ErrNotFound package typo

### DIFF
--- a/Chapter02/src/metadata/internal/handler/http/http.go
+++ b/Chapter02/src/metadata/internal/handler/http/http.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"movieexample.com/metadata/internal/controller/metadata"
-	"movieexample.com/metadata/internal/repository"
 )
 
 // Handler defines a movie metadata HTTP handler.
@@ -29,7 +28,7 @@ func (h *Handler) GetMetadata(w http.ResponseWriter, req *http.Request) {
 	}
 	ctx := req.Context()
 	m, err := h.ctrl.Get(ctx, id)
-	if err != nil && errors.Is(err, repository.ErrNotFound) {
+	if err != nil && errors.Is(err, metadata.ErrNotFound) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	} else if err != nil {


### PR DESCRIPTION
Repository not found errors never reach the handler. It's an error from the controller, not from the repository:

https://github.com/PacktPublishing/Microservices-with-Go/blob/338ef732b987f3a881ce50c2c7fdfd0195c9c9a4/Chapter02/src/metadata/internal/controller/metadata/controller.go#L31-L33